### PR TITLE
Reduces the number of swing events to improve the simulation speed.

### DIFF
--- a/src/main/java/com/github/itoshkov/digitaln2t/HackDisplay.java
+++ b/src/main/java/com/github/itoshkov/digitaln2t/HackDisplay.java
@@ -225,13 +225,19 @@ public class HackDisplay extends Node implements Element, RAMInterface {
         return addrBits;
     }
 
+    private long lastUpdate = 0;
+
     private void updateGraphic() {
-        SwingUtilities.invokeLater(() -> {
-            if (graphicsDialog == null || !graphicsDialog.isVisible()) {
-                graphicsDialog = new HackGraphicsDialog(image, scaleFactor);
-                getModel().getWindowPosManager().register("HackDisplay_" + label, graphicsDialog);
-            }
-            graphicsDialog.updateGraphic();
-        });
+        long time = System.currentTimeMillis();
+        if (time - lastUpdate > 10) {  // not more than 100 repaints per second
+            SwingUtilities.invokeLater(() -> {
+                if (graphicsDialog == null || !graphicsDialog.isVisible()) {
+                    graphicsDialog = new HackGraphicsDialog(image, scaleFactor);
+                    getModel().getWindowPosManager().register("HackDisplay_" + label, graphicsDialog);
+                }
+                graphicsDialog.updateGraphic();
+            });
+            lastUpdate = time;
+        }
     }
 }


### PR DESCRIPTION
Not sure this modification helps a lot. It depends on how often you write to the graphic RAM.
I have tested it under the extreme condition that at every clock cycle a RAM write is performed.
In this case it improves the speed four times. If you are writing to the RAM at a lower frequency it maybe that this modification has no effect on the performance.